### PR TITLE
Evaluate FID and KID

### DIFF
--- a/mmedit/core/evaluation/inception_utils.py
+++ b/mmedit/core/evaluation/inception_utils.py
@@ -373,7 +373,7 @@ class StyleGANInceptionV3(nn.Module):
             return self.inception(inp, return_features=True)
 
 
-def load_inception(style: str = 'StyleGAN', **inception_kwargs):
+def load_inception(style='StyleGAN', **inception_kwargs):
     """Load Inception Model from given `style` and `inception_kwargs`.
 
     This function would try to load Inception under the guidance of `style`

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -18,7 +18,8 @@ class InceptionV3:
     """
 
     def __init__(self, style='StyleGAN', device='cpu', **inception_kwargs):
-        self.inception = load_inception(style=style, **inception_kwargs)
+        self.inception = load_inception(
+            style=style, **inception_kwargs).eval().to(device)
         self.style = style
         self.device = device
 

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -11,6 +11,8 @@ class InceptionV3:
     """Feature extractor features using InceptionV3 model.
 
     Args:
+        style (str): The model style to run Inception model. it must be either
+            'StyleGAN' or 'pytorch'.
         device (torch.device): device to extract feature.
         inception_kwargs (**kwargs): kwargs for InceptionV3.
     """

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -18,7 +18,7 @@ class InceptionV3:
     """
 
     def __init__(self, style='StyleGAN', device='cpu', **inception_kwargs):
-        self.inception = load_inception(style, inception_kwargs)
+        self.inception = load_inception(style=style, **inception_kwargs)
         self.style = style
         self.device = device
 
@@ -52,11 +52,11 @@ class InceptionV3:
         return self.inception(x)[-1].view(x.shape[0], -1).cpu()
 
 
-def frechet_distance(X, Y, eps=1e-6):
+def frechet_distance(X, Y):
     """Compute the frechet distance."""
 
-    muX, covX = np.mean(X, axis=0), np.cov(X, rowvar=False) + eps
-    muY, covY = np.mean(Y, axis=0), np.cov(Y, rowvar=False) + eps
+    muX, covX = np.mean(X, axis=0), np.cov(X, rowvar=False)
+    muY, covY = np.mean(Y, axis=0), np.cov(Y, rowvar=False)
 
     cov_sqrt = linalg.sqrtm(covX.dot(covY))
     frechet_distance = np.square(muX - muY).sum() + np.trace(covX) + np.trace(

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -60,17 +60,13 @@ class InceptionV3:
 def frechet_distance(X, Y, eps=1e-6):
     """Compute the frechet distance."""
 
-    muX, covX = np.mean(X, axis=0), np.cov(X, rowvar=False) + eps
-    muY, covY = np.mean(Y, axis=0), np.cov(Y, rowvar=False) + eps
+    muX, covX = np.mean(X, axis=0, dtype=np.float64), np.cov(X, rowvar=False)
+    muY, covY = np.mean(Y, axis=0, dtype=np.float64), np.cov(Y, rowvar=False)
 
-    diff = muX - muY
     cov_sqrt = linalg.sqrtm(covX.dot(covY))
-    if np.iscomplexobj(cov_sqrt):
-        cov_sqrt = cov_sqrt.real
-
-    frechet_distance = diff.dot(diff) + np.trace(covX) + np.trace(
+    frechet_distance = np.square(muX - muY).sum() + np.trace(covX) + np.trace(
         covY) - 2 * np.trace(cov_sqrt)
-    return frechet_distance
+    return np.real(frechet_distance)
 
 
 @METRICS.register_module()

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -16,7 +16,10 @@ class InceptionV3:
     """
 
     def __init__(self, device='cpu', **inception_kwargs):
-        self.inception = _InceptionV3(**inception_kwargs).to(device)
+        # self.inception = _InceptionV3(**inception_kwargs).to(device)
+        self.inception = _load_inception_from_url(
+            'https://nvlabs-fi-cdn.nvidia.com/stylegan2-ada-pytorch/pretrained/metrics/inception-2015-12-05.pt'
+        ).to(device).eval()
         self.device = device
 
     def __call__(self, img1, img2, crop_border=0):
@@ -37,12 +40,15 @@ class InceptionV3:
     def img2tensor(self, img):
         img = img.transpose((2, 0, 1))
         img = np.expand_dims(img, axis=0)
-        return torch.from_numpy(img / 255.).to(
-            device=self.device, dtype=torch.float32)
+        #return torch.from_numpy(img / 255.).to(
+        #    device=self.device, dtype=torch.float32)
+        return torch.tensor(img).to(device=self.device, dtype=torch.uint8)
 
     def forward_inception(self, x):
-        with torch.no_grad():
-            return self.inception(x)[0].view(x.shape[0], -1).cpu()
+        #with torch.no_grad():
+        with disable_gpu_fuser_on_pt19():
+            return self.inception(
+                x, return_features=True).cpu()  #[0].view(x.shape[0], -1).cpu()
 
 
 def frechet_distance(X, Y, eps=1e-6):
@@ -137,3 +143,154 @@ class KID:
             kid.append(mmd2(X_, Y_, biased=self.biased))
         kid = np.array(kid)
         return dict(KID_MEAN=kid.mean(), KID_STD=kid.std())
+
+
+import hashlib
+import os
+
+import click
+import requests
+import torch.distributed as dist
+import torch.nn as nn
+from requests.exceptions import InvalidURL, RequestException, Timeout
+
+MMEDIT_CACHE_DIR = os.path.expanduser('~') + '/.cache/openmmlab/mmedit/'
+
+
+def get_content_from_url(url, timeout=15, stream=False):
+    """Get content from url.
+
+    Args:
+        url (str): Url for getting content.
+        timeout (int): Set the socket timeout. Default: 15.
+    """
+    try:
+        response = requests.get(url, timeout=timeout, stream=stream)
+    except InvalidURL as err:
+        raise err  # type: ignore
+    except Timeout as err:
+        raise err  # type: ignore
+    except RequestException as err:
+        raise err  # type: ignore
+    except Exception as err:
+        raise err  # type: ignore
+    return response
+
+
+def download_from_url(url,
+                      dest_path=None,
+                      dest_dir=MMEDIT_CACHE_DIR,
+                      hash_prefix=None):
+    """Download object at the given URL to a local path.
+
+    Args:
+        url (str): URL of the object to download.
+        dest_path (str): Path where object will be saved.
+        dest_dir (str): The directory of the destination. Defaults to
+            ``'~/.cache/openmmlab/mmgen/'``.
+        hash_prefix (string, optional): If not None, the SHA256 downloaded
+            file should start with `hash_prefix`. Default: None.
+    Return:
+        str: path for the downloaded file.
+    """
+    # get the exact destination path
+    if dest_path is None:
+        filename = url.split('/')[-1]
+        dest_path = os.path.join(dest_dir, filename)
+
+    if dest_path.startswith('~'):
+        dest_path = os.path.expanduser('~') + dest_path[1:]
+
+    # advoid downloading existed file
+    if os.path.exists(dest_path):
+        return dest_path
+
+    rank, ws = 0, 1
+
+    # only download from the master process
+    if rank == 0:
+        # mkdir
+        _dir = os.path.dirname(dest_path)
+        os.makedirs(_dir, exist_ok=True)
+
+        if hash_prefix is not None:
+            sha256 = hashlib.sha256()
+
+        response = get_content_from_url(url, stream=True)
+        size = int(response.headers.get('content-length'))
+        with open(dest_path, 'wb') as fw:
+            content_iter = response.iter_content(chunk_size=1024)
+            with click.progressbar(content_iter, length=size / 1024) as chunks:
+                for chunk in chunks:
+                    if chunk:
+                        fw.write(chunk)
+                        fw.flush()
+                        if hash_prefix is not None:
+                            sha256.update(chunk)
+
+        if hash_prefix is not None:
+            digest = sha256.hexdigest()
+            if digest[:len(hash_prefix)] != hash_prefix:
+                raise RuntimeError(
+                    f'invalid hash value, expected "{hash_prefix}", but got '
+                    f'"{digest}"')
+
+    # sync the other processes
+    if ws > 1:
+        dist.barrier()
+
+    return dest_path
+
+
+def _load_inception_from_path(inception_path):
+    """Load inception from passed path.
+
+    Args:
+        inception_path (str): The path of inception.
+    Returns:
+        nn.Module: The loaded inception.
+    """
+    print('Try to load Tero\'s Inception Model from '
+          f'\'{inception_path}\'.', 'current')
+    try:
+        model = torch.jit.load(inception_path)
+        print('Load Tero\'s Inception Model successfully.', 'current')
+    except Exception as e:
+        model = None
+        print('Load Tero\'s Inception Model failed. '
+              f'\'{e}\' occurs.', 'current')
+    return model
+
+
+def _load_inception_from_url(inception_url: str) -> nn.Module:
+    """Load Inception network from the give `inception_url`"""
+    inception_url = inception_url if inception_url else TERO_INCEPTION_URL
+    print(f'Try to download Inception Model from {inception_url}...',
+          'current')
+    try:
+        path = download_from_url(inception_url, dest_dir=MMEDIT_CACHE_DIR)
+        print('Download Finished.', 'current')
+        return _load_inception_from_path(path)
+    except Exception as e:
+        print(f'Download Failed. {e} occurs.', 'current')
+        return None
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def disable_gpu_fuser_on_pt19():
+    """On PyTorch 1.9 a CUDA fuser bug prevents the Inception JIT model to run.
+
+    Refers to:
+      https://github.com/GaParmar/clean-fid/blob/5e1e84cdea9654b9ac7189306dfa4057ea2213d8/cleanfid/inception_torchscript.py#L9  # noqa
+      https://github.com/GaParmar/clean-fid/issues/5
+      https://github.com/pytorch/pytorch/issues/64062
+    """
+    if torch.__version__.startswith('1.9.'):
+        old_val = torch._C._jit_can_fuse_on_gpu()
+        torch._C._jit_override_can_fuse_on_gpu(False)
+    yield
+    if torch.__version__.startswith('1.9.'):
+        torch._C._jit_override_can_fuse_on_gpu(old_val)

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -4,7 +4,7 @@ import torch
 from scipy import linalg
 
 from ..registry import METRICS
-from .inception_utils import PyTorchInceptionV3, StyleGANInceptionV3
+from .inception_utils import load_inception
 
 
 class InceptionV3:
@@ -16,14 +16,7 @@ class InceptionV3:
     """
 
     def __init__(self, style='StyleGAN', device='cpu', **inception_kwargs):
-        if style == 'StyleGAN':
-            inception = StyleGANInceptionV3(
-                'https://nvlabs-fi-cdn.nvidia.com/stylegan2-ada-pytorch/pretrained/metrics/inception-2015-12-05.pt'  # noqa: E501
-            )
-        else:
-            inception = PyTorchInceptionV3(**inception_kwargs)
-        self.inception = inception.to(device).eval()
-
+        self.inception = load_inception(style, inception_kwargs)
         self.style = style
         self.device = device
 

--- a/mmedit/core/evaluation/inceptions.py
+++ b/mmedit/core/evaluation/inceptions.py
@@ -60,8 +60,8 @@ class InceptionV3:
 def frechet_distance(X, Y, eps=1e-6):
     """Compute the frechet distance."""
 
-    muX, covX = np.mean(X, axis=0, dtype=np.float64), np.cov(X, rowvar=False)
-    muY, covY = np.mean(Y, axis=0, dtype=np.float64), np.cov(Y, rowvar=False)
+    muX, covX = np.mean(X, axis=0), np.cov(X, rowvar=False) + eps
+    muY, covY = np.mean(Y, axis=0), np.cov(Y, rowvar=False) + eps
 
     cov_sqrt = linalg.sqrtm(covX.dot(covY))
     frechet_distance = np.square(muX - muY).sum() + np.trace(covX) + np.trace(

--- a/tests/test_metrics/test_inceptions.py
+++ b/tests/test_metrics/test_inceptions.py
@@ -3,8 +3,6 @@ import numpy as np
 import pytest
 import torch
 
-from mmedit.core.evaluation.inception_utils import (PyTorchInceptionV3,
-                                                    StyleGANInceptionV3)
 from mmedit.core.evaluation.inceptions import FID, KID, InceptionV3
 
 
@@ -18,7 +16,6 @@ def test_inception():
 
     # for StyleGAN style inception
     inception = InceptionV3(style='StyleGAN')
-    assert isinstance(inception.inception, StyleGANInceptionV3)
 
     t = inception.img2tensor(img1)
     assert isinstance(t, torch.Tensor)
@@ -31,7 +28,6 @@ def test_inception():
 
     # for PyTorch style inception
     inception = InceptionV3(style='pytorch')
-    assert isinstance(inception.inception, PyTorchInceptionV3)
 
     t = inception.img2tensor(img1)
     assert isinstance(t, torch.Tensor)

--- a/tests/test_metrics/test_inceptions.py
+++ b/tests/test_metrics/test_inceptions.py
@@ -3,8 +3,7 @@ import mmcv
 import numpy as np
 import pytest
 
-from mmedit.core.evaluation.metrics import (
-    InceptionV3, FID, KID)
+from mmedit.core.evaluation.metrics import FID, KID, InceptionV3
 
 
 def test_inception():
@@ -18,8 +17,7 @@ def test_inception():
 def test_fid():
     model = InceptionV3()
     feats = [
-        model(np.random.randint(0, 256, (224, 224, 3)))
-        for _ in range(10)
+        model(np.random.randint(0, 256, (224, 224, 3))) for _ in range(10)
     ]
     X, Y = zip(*feats)
     X, Y = np.array(X), np.array(Y)
@@ -31,8 +29,7 @@ def test_fid():
 def test_kid():
     model = InceptionV3()
     feats = [
-        model(np.random.randint(0, 256, (224, 224, 3)))
-        for _ in range(10)
+        model(np.random.randint(0, 256, (224, 224, 3))) for _ in range(10)
     ]
     X, Y = zip(*feats)
     X, Y = np.array(X), np.array(Y)

--- a/tests/test_metrics/test_inceptions.py
+++ b/tests/test_metrics/test_inceptions.py
@@ -1,1 +1,41 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import mmcv
+import numpy as np
+import pytest
+
+from mmedit.core.evaluation.metrics import (
+    InceptionV3, FID, KID)
+
+
+def test_inception():
+    model = InceptionV3()
+    feats = model(np.random.randint(0, 256, (224, 224, 3)))
+    assert len(feats) == 2
+    assert feats[0].shape == (1, 2048)
+    assert feats[1].shape == (1, 2048)
+
+
+def test_fid():
+    model = InceptionV3()
+    feats = [
+        model(np.random.randint(0, 256, (224, 224, 3)))
+        for _ in range(10)
+    ]
+    X, Y = zip(*feats)
+    X, Y = np.array(X), np.array(Y)
+
+    fid = FID()
+    assert np.allclose()
+
+
+def test_kid():
+    model = InceptionV3()
+    feats = [
+        model(np.random.randint(0, 256, (224, 224, 3)))
+        for _ in range(10)
+    ]
+    X, Y = zip(*feats)
+    X, Y = np.array(X), np.array(Y)
+
+    kid = KID()
+    assert np.allclose()

--- a/tests/test_metrics/test_inceptions.py
+++ b/tests/test_metrics/test_inceptions.py
@@ -3,31 +3,40 @@ import numpy as np
 import pytest
 import torch
 
-from mmedit.core.evaluation.metrics import FID, KID, InceptionV3
+from mmedit.core.evaluation.inception_utils import (PyTorchInceptionV3,
+                                                    StyleGANInceptionV3)
+from mmedit.core.evaluation.inceptions import FID, KID, InceptionV3
 
 
 def test_inception():
     img1 = np.random.randint(0, 256, (224, 224, 3))
     img2 = np.random.randint(0, 256, (224, 224, 3))
 
-    # test `img2tensor` and `forward_inception` method
-    # for StyleGAN style's inception
+    # for StyleGAN style inception
     inception = InceptionV3(style='StyleGAN')
+    assert isinstance(inception.inception, StyleGANInceptionV3)
+
     t = inception.img2tensor(img1)
     assert isinstance(t, torch.Tensor)
     assert t.dtype == torch.uint8
     assert t.shape == (1, 3, 224, 224)
+
     t = inception.forward_inception(t)
+    assert t.device == torch.device('cpu')
     assert t.shape == (1, 2048)
 
-    # test `img2tensor` and `forward_inception` method for PyTorch style's one
+    # for PyTorch style inception
     inception = InceptionV3(style=None)
+    assert isinstance(inception.inception, PyTorchInceptionV3)
+
     t = inception.img2tensor(img1)
     assert isinstance(t, torch.Tensor)
     assert t.dtype == torch.float32
     assert t.shape == (1, 3, 224, 224)
-    assert 0 <= t <= 1
+    assert np.logical_and(0 <= t, t <= 1).all()
+
     t = inception.forward_inception(t)
+    assert t.device == torch.device('cpu')
     assert t.shape == (1, 2048)
 
     # test `__call__` method in cpu
@@ -50,7 +59,7 @@ def test_fid():
     fid = FID()
     fid_result = fid(np.ones((10, 2048)), np.ones((10, 2048)))
     assert isinstance(fid_result, float)
-    assert np.testing.assert_equal(fid_result, 0)
+    assert fid_result == 0.0
 
 
 def test_kid():
@@ -58,8 +67,8 @@ def test_kid():
     kid_result = kid(np.ones((10, 2048)), np.ones((10, 2048)))
     assert isinstance(kid_result, dict)
     assert 'KID_MEAN' in kid_result and 'KID_STD' in kid_result
-    assert np.testing.assert_equal(kid_result['KID_MEAN'], 0)
-    assert np.testing.assert_equal(kid_result['KID_STD'], 0)
+    assert kid_result['KID_MEAN'] == 0.0
+    assert kid_result['KID_STD'] == 0.0
 
     # if sample size > number of samples
     with pytest.raises(ValueError):

--- a/tests/test_metrics/test_inceptions.py
+++ b/tests/test_metrics/test_inceptions.py
@@ -12,6 +12,10 @@ def test_inception():
     img1 = np.random.randint(0, 256, (224, 224, 3))
     img2 = np.random.randint(0, 256, (224, 224, 3))
 
+    # style must be either StyleGAN or pytorch
+    with pytest.raises(AssertionError):
+        inception = InceptionV3(style='some')
+
     # for StyleGAN style inception
     inception = InceptionV3(style='StyleGAN')
     assert isinstance(inception.inception, StyleGANInceptionV3)
@@ -26,7 +30,7 @@ def test_inception():
     assert t.shape == (1, 2048)
 
     # for PyTorch style inception
-    inception = InceptionV3(style=None)
+    inception = InceptionV3(style='pytorch')
     assert isinstance(inception.inception, PyTorchInceptionV3)
 
     t = inception.img2tensor(img1)

--- a/tests/test_metrics/test_inceptions.py
+++ b/tests/test_metrics/test_inceptions.py
@@ -1,38 +1,67 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import mmcv
 import numpy as np
 import pytest
+import torch
 
 from mmedit.core.evaluation.metrics import FID, KID, InceptionV3
 
 
 def test_inception():
-    model = InceptionV3()
-    feats = model(np.random.randint(0, 256, (224, 224, 3)))
-    assert len(feats) == 2
+    img1 = np.random.randint(0, 256, (224, 224, 3))
+    img2 = np.random.randint(0, 256, (224, 224, 3))
+
+    # test `img2tensor` and `forward_inception` method
+    # for StyleGAN style's inception
+    inception = InceptionV3(style='StyleGAN')
+    t = inception.img2tensor(img1)
+    assert isinstance(t, torch.Tensor)
+    assert t.dtype == torch.uint8
+    assert t.shape == (1, 3, 224, 224)
+    t = inception.forward_inception(t)
+    assert t.shape == (1, 2048)
+
+    # test `img2tensor` and `forward_inception` method for PyTorch style's one
+    inception = InceptionV3(style=None)
+    t = inception.img2tensor(img1)
+    assert isinstance(t, torch.Tensor)
+    assert t.dtype == torch.float32
+    assert t.shape == (1, 3, 224, 224)
+    assert 0 <= t <= 1
+    t = inception.forward_inception(t)
+    assert t.shape == (1, 2048)
+
+    # test `__call__` method in cpu
+    inception = InceptionV3(device='cpu')
+    feats = inception(img1, img2)
+    assert isinstance(feats, tuple) and len(feats) == 2
     assert feats[0].shape == (1, 2048)
     assert feats[1].shape == (1, 2048)
 
+    # test `__call__` method in cuda
+    if torch.cuda.is_available():
+        inception = InceptionV3(device='cuda')
+        feats = inception(img1, img2)
+        assert isinstance(feats, tuple) and len(feats) == 2
+        assert feats[0].shape == (1, 2048)
+        assert feats[1].shape == (1, 2048)
+
 
 def test_fid():
-    model = InceptionV3()
-    feats = [
-        model(np.random.randint(0, 256, (224, 224, 3))) for _ in range(10)
-    ]
-    X, Y = zip(*feats)
-    X, Y = np.array(X), np.array(Y)
-
     fid = FID()
-    assert np.allclose()
+    fid_result = fid(np.ones((10, 2048)), np.ones((10, 2048)))
+    assert isinstance(fid_result, float)
+    assert np.testing.assert_equal(fid_result, 0)
 
 
 def test_kid():
-    model = InceptionV3()
-    feats = [
-        model(np.random.randint(0, 256, (224, 224, 3))) for _ in range(10)
-    ]
-    X, Y = zip(*feats)
-    X, Y = np.array(X), np.array(Y)
+    kid = KID(num_repeats=1, sample_size=10)
+    kid_result = kid(np.ones((10, 2048)), np.ones((10, 2048)))
+    assert isinstance(kid_result, dict)
+    assert 'KID_MEAN' in kid_result and 'KID_STD' in kid_result
+    assert np.testing.assert_equal(kid_result['KID_MEAN'], 0)
+    assert np.testing.assert_equal(kid_result['KID_STD'], 0)
 
-    kid = KID()
-    assert np.allclose()
+    # if sample size > number of samples
+    with pytest.raises(ValueError):
+        kid = KID(sample_size=100)
+        kid_result = kid(np.ones((10, 2048)), np.ones((10, 2048)))


### PR DESCRIPTION
Compare results of FID and KID with results of [StyleGAN](https://github.com/NVlabs/stylegan3) repo.

## Random A
| | FID | KID |
|-|-|-|
| MMEdit | 10.145473300110936 | 0.0005655973800502423 |
| StyleGAN | 10.050122002713657 | 0.000571023121843541 |

## Random B
- todo

## AFHQ
### Data preparation
```bash
# for real images
python dataset_tool.py --source=../data/afhqv2 --dest=data/afhqv2-512x512.zip

# for fake images
python gen_images.py --outdir=out --trunc=1 --seeds=1-50000 \
    --network=https://api.ngc.nvidia.com/v2/models/nvidia/research/stylegan2/versions/1/files/stylegan2-afhqv2-512x512.pkl
```

| | FID | KID |
|-|-|-|
| MMEdit | 6.197829331183584 | 0.0021816461886887063 |
| StyleGAN | 6.202439159578144 | 0.002163134474474473 |


### TODO
- [x] Prototyping `InceptionV3` with `style='StyleGAN'`
- [x] Testing `FID`, `KID` and `InceptionV3` modules